### PR TITLE
Compile aptos-node package separately

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -45,10 +45,26 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Bake binaries and populate cache
+      - name: Bake and populate builder-base cache
+        if: github.event_name == 'push'
         uses: docker/bake-action@v5
         with:
-          targets: binaries
+          targets: cache-builder-base
+        env:
+          PLATFORM: ${{ matrix.platform }}
+
+      - name: Bake and populate runtime-base cache
+        if: github.event_name == 'push'
+        uses: docker/bake-action@v5
+        with:
+          targets: cache-runtime-base
+        env:
+          PLATFORM: ${{ matrix.platform }}
+
+      - name: Bake and populate binaries cache
+        uses: docker/bake-action@v5
+        with:
+          targets: cache-binaries
         env:
           PLATFORM: ${{ matrix.platform }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN git init && \
     git fetch --depth 1 origin ${APTOS_GIT_REVISION} && \
     git checkout FETCH_HEAD
 
-RUN cargo build --locked --release --bin aptos-node
+RUN cargo build --locked --release --package aptos-node
 RUN cargo build --locked --profile cli --bin aptos
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Keep up-to-date with https://github.com/aptos-labs/aptos-core/blob/main/rust-toolchain.toml
-FROM rust:1.78.0-slim-bookworm AS builder
+FROM rust:1.78.0-slim-bookworm AS builder-base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -14,6 +14,9 @@ RUN apt-get update && \
         clang-14 \
         && \
     rm -rf /var/lib/apt/lists/*
+
+
+FROM builder-base AS builder
 
 WORKDIR /usr/src/aptos
 
@@ -39,7 +42,7 @@ COPY --from=builder \
     /usr/local/bin/
 
 
-FROM debian:bookworm-slim AS runtime
+FROM debian:bookworm-slim AS runtime-base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -60,7 +63,7 @@ WORKDIR /aptos
 RUN touch .dockerenv
 
 
-FROM runtime AS aptos
+FROM runtime-base AS aptos
 
 COPY --from=binaries \
     /usr/local/bin/aptos \
@@ -71,7 +74,7 @@ USER aptos
 ENTRYPOINT ["/usr/local/bin/aptos"]
 
 
-FROM runtime AS aptos-node
+FROM runtime-base AS aptos-node
 
 COPY --from=binaries \
     /usr/local/bin/aptos-node \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -6,8 +6,21 @@ variable "_PLATFORM_TAG" {
   default = regex_replace(PLATFORM, "/", "-")
 }
 
-variable "_REMOTE_CACHE" {
+# TODO - delete
+variable "_REMOTE_CACHE_LEGACY" {
   default = "type=registry,ref=ghcr.io/shinamicorp/aptos:cache-${_PLATFORM_TAG}"
+}
+
+variable "_REMOTE_CACHE_BUILDER_BASE" {
+  default = "type=registry,ref=ghcr.io/shinamicorp/aptos:cache-builder-base-${_PLATFORM_TAG}"
+}
+
+variable "_REMOTE_CACHE_RUNTIME_BASE" {
+  default = "type=registry,ref=ghcr.io/shinamicorp/aptos:cache-runtime-base-${_PLATFORM_TAG}"
+}
+
+variable "_REMOTE_CACHE_BINARIES" {
+  default = "type=registry,ref=ghcr.io/shinamicorp/aptos:cache-binaries-${APTOS_GIT_REVISION}-${_PLATFORM_TAG}"
 }
 
 function "tag" {
@@ -15,20 +28,47 @@ function "tag" {
   result = "ghcr.io/shinamicorp/${target}:${APTOS_GIT_REVISION}-${_PLATFORM_TAG}"
 }
 
+function "local_cache_dir" {
+  params = [target]
+  result = "./cache/${PLATFORM}/${target}"
+}
+
 target "_common" {
   platforms = [PLATFORM]
   args = {
     APTOS_GIT_REVISION = APTOS_GIT_REVISION
   }
-  cache-from = ["type=local,src=./cache/${PLATFORM}", _REMOTE_CACHE]
+  cache-from = [
+    "type=local,src=${local_cache_dir("builder-base")}",
+    "type=local,src=${local_cache_dir("runtime-base")}",
+    "type=local,src=${local_cache_dir("binaries")}",
+    _REMOTE_CACHE_BUILDER_BASE,
+    _REMOTE_CACHE_RUNTIME_BASE,
+    _REMOTE_CACHE_BINARIES,
+    _REMOTE_CACHE_LEGACY,
+  ]
 }
 
-# A cache-only target, just to download/populate the cache.
-target "binaries" {
+# These cache-only targets are just to download/populate the caches.
+target "cache-builder-base" {
+  inherits = ["_common"]
+  target   = "builder-base"
+  output   = ["type=cacheonly"]
+  cache-to = ["type=local,dest=${local_cache_dir("builder-base")}", _REMOTE_CACHE_BUILDER_BASE]
+}
+
+target "cache-runtime-base" {
+  inherits = ["_common"]
+  target   = "runtime-base"
+  output   = ["type=cacheonly"]
+  cache-to = ["type=local,dest=${local_cache_dir("runtime-base")}", _REMOTE_CACHE_RUNTIME_BASE]
+}
+
+target "cache-binaries" {
   inherits = ["_common"]
   target   = "binaries"
   output   = ["type=cacheonly"]
-  cache-to = ["type=local,dest=./cache/${PLATFORM}", _REMOTE_CACHE]
+  cache-to = ["type=local,dest=${local_cache_dir("binaries")}", _REMOTE_CACHE_BINARIES]
 }
 
 # Single-platform targets.


### PR DESCRIPTION
https://github.com/shinamicorp/aptos-docker/pull/13 incorrectly changed how `aptos-node` is compiled, causing the following error

```
thread 'main' panicked at aptos-move/aptos-vm/src/natives.rs:189:5:
aptos-node was compiled with feature flags that shouldn't be enabled.
This is caused by cargo's feature unification.
When you compile two crates with a shared dependency, if one enables a feature flag for the dependency, then it is also enabled for the other crate.
PLEASE RECOMPILE APTOS-NODE SEPARATELY using the following command:
    cargo build --package aptos-node
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```