### PR TITLE
Build aptos-node-v1.23.3

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -18,19 +18,14 @@ jobs:
   prep:
     runs-on: ubuntu-latest
     outputs:
-      aptos_git_sha: ${{ steps.resolve.outputs.aptos_git_sha }}
+      aptos_git_sha: ${{ steps.checkout.outputs.commit }}
     steps:
       - name: Checkout aptos-core
+        id: checkout
         uses: actions/checkout@v4
         with:
           repository: aptos-labs/aptos-core
           ref: ${{ env.APTOS_GIT_REF }}
-
-      - name: Resolve aptos-core commit SHA
-        id: resolve
-        run: |
-          sha=$(git rev-list -n1 HEAD)
-          echo "aptos_git_sha=$sha" | tee -a "$GITHUB_OUTPUT"
 
   build_push:
     permissions:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -18,7 +18,7 @@ jobs:
   prep:
     runs-on: ubuntu-latest
     outputs:
-      aptos_git_sha: $${{ steps.resolve.outputs.aptos_git_sha }}
+      aptos_git_sha: ${{ steps.resolve.outputs.aptos_git_sha }}
     steps:
       - name: Checkout aptos-core
         uses: actions/checkout@v4

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -10,11 +10,28 @@ on:
       - main
 
 env:
-  APTOS_GIT_REVISION: aptos-node-v1.23.2
+  APTOS_GIT_REF: aptos-node-v1.23.3
 
 concurrency: docker
 
 jobs:
+  prep:
+    runs-on: ubuntu-latest
+    outputs:
+      aptos_git_sha: $${{ steps.resolve.outputs.aptos_git_sha }}
+    steps:
+      - name: Checkout aptos-core
+        uses: actions/checkout@v4
+        with:
+          repository: aptos-labs/aptos-core
+          ref: ${{ env.APTOS_GIT_REF }}
+
+      - name: Resolve aptos-core commit SHA
+        id: resolve
+        run: |
+          sha=$(git rev-list -n1 HEAD)
+          echo "aptos_git_sha=$sha" | tee -a "$GITHUB_OUTPUT"
+
   build_push:
     permissions:
       contents: read
@@ -28,6 +45,10 @@ jobs:
           - runner: ARM64
             platform: linux/arm64
 
+    needs: prep
+    env:
+      APTOS_GIT_REF: ${{ needs.prep.outputs.aptos_git_sha }}
+      PLATFORM: ${{ matrix.platform }}
     runs-on:
       - self-hosted
       - ${{ matrix.runner }}
@@ -50,23 +71,17 @@ jobs:
         uses: docker/bake-action@v5
         with:
           targets: cache-builder-base,cache-runtime-base
-        env:
-          PLATFORM: ${{ matrix.platform }}
 
       - name: Bake and populate binaries cache
         uses: docker/bake-action@v5
         with:
           targets: cache-binaries
-        env:
-          PLATFORM: ${{ matrix.platform }}
 
       - name: Bake images
         uses: docker/bake-action@v5
         with:
           targets: aptos-node,aptos
           push: ${{ github.event_name == 'push' }}
-        env:
-          PLATFORM: ${{ matrix.platform }}
 
   manifest:
     permissions:
@@ -77,7 +92,7 @@ jobs:
       matrix:
         target: [aptos-node, aptos]
 
-    needs: build_push
+    needs: [prep, build_push]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
@@ -90,6 +105,6 @@ jobs:
 
       - name: Create manifest
         run: |
-          docker buildx imagetools create -t ghcr.io/shinamicorp/${{ matrix.target }}:${{ env.APTOS_GIT_REVISION }} \
-            ghcr.io/shinamicorp/${{ matrix.target }}:${{ env.APTOS_GIT_REVISION }}-linux-amd64 \
-            ghcr.io/shinamicorp/${{ matrix.target }}:${{ env.APTOS_GIT_REVISION }}-linux-arm64 \
+          docker buildx imagetools create -t ghcr.io/shinamicorp/${{ matrix.target }}:${{ env.APTOS_GIT_REF }} \
+            ghcr.io/shinamicorp/${{ matrix.target }}:${{ needs.prep.outputs.aptos_git_sha }}-linux-amd64 \
+            ghcr.io/shinamicorp/${{ matrix.target }}:${{ needs.prep.outputs.aptos_git_sha }}-linux-arm64 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ FROM builder-base AS builder
 WORKDIR /usr/src/aptos
 
 # Shallow clone of a specific commit
-ARG APTOS_GIT_REVISION
+ARG APTOS_GIT_REF
 RUN git init && \
     git remote add origin https://github.com/aptos-labs/aptos-core.git && \
-    git fetch --depth 1 origin ${APTOS_GIT_REVISION} && \
+    git fetch --depth 1 origin ${APTOS_GIT_REF} && \
     git checkout FETCH_HEAD
 
 RUN cargo build --locked --release --package aptos-node

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,4 +1,4 @@
-variable "APTOS_GIT_REVISION" {}
+variable "APTOS_GIT_REF" {}
 
 variable "PLATFORM" {}
 
@@ -15,12 +15,12 @@ variable "_REMOTE_CACHE_RUNTIME_BASE" {
 }
 
 variable "_REMOTE_CACHE_BINARIES" {
-  default = "type=registry,ref=ghcr.io/shinamicorp/aptos:cache-binaries-${APTOS_GIT_REVISION}-${_PLATFORM_TAG}"
+  default = "type=registry,ref=ghcr.io/shinamicorp/aptos:cache-binaries-${APTOS_GIT_REF}-${_PLATFORM_TAG}"
 }
 
 function "tag" {
   params = [target]
-  result = "ghcr.io/shinamicorp/${target}:${APTOS_GIT_REVISION}-${_PLATFORM_TAG}"
+  result = "ghcr.io/shinamicorp/${target}:${APTOS_GIT_REF}-${_PLATFORM_TAG}"
 }
 
 function "local_cache_dir" {
@@ -31,7 +31,7 @@ function "local_cache_dir" {
 target "_common" {
   platforms = [PLATFORM]
   args = {
-    APTOS_GIT_REVISION = APTOS_GIT_REVISION
+    APTOS_GIT_REF = APTOS_GIT_REF
   }
   cache-from = [
     "type=local,src=${local_cache_dir("builder-base")}",


### PR DESCRIPTION
Also decouple the target ref from the actual commit. Always (re)resolve the target ref into the commit SHA before building, and cache the binaries image based on SHA instead. This improves both of these scenarios:

- Building a new tag on an existing (already built) commit. No need to manually retag or rebuild the image.
- Rebuilding an existing tag which has been updated to point to a new commit. No need to manually delete the cache image to trigger rebuild.


[sc-4521]